### PR TITLE
minor non-aws search fixes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,24 +18,25 @@ directory '/var/run/elasticsearch' do
 end
 
 es_cluster_name = node['elasticsearch']['cluster_name'] || 'elasticsearch'
-query = "chef_environment:#{node.chef_environment} AND es_cluster:#{es_cluster_name}"
+query = "chef_environment:#{node.chef_environment} AND cluster_name:#{es_cluster_name}"
 Chef::Log.warn "query: #{query}"
 cluster_members = []
 search(:node, query, filter_result: { 'fqdn' => ['fqdn'] }).each do |result|
   cluster_members << result['fqdn']
 end
+listen_ip = node['ipaddress']
 
 Chef::Log.warn "cluster members #{cluster_members}"
 
 elasticsearch_config = Hash.new.tap do |es_hash|
   es_hash['cluster.name'] = es_cluster_name
   es_hash['node.name'] = node['hostname']
-  es_hash['network.host'] = node['ipaddress'],
+  es_hash['network.host'] = listen_ip,
   if node['aws'] && node['aws'].has_key?('region')
     es_hash['discovery.type'] = 'ec2'
     es_hash['cloud.aws.region'] = node['aws']['region']
   else
-    es_hash['discovery.zen.ping.unicast.hosts'] = cluster_members
+    es_hash['discovery.zen.ping.unicast.hosts'] = cluster_members.sort
   end
   es_hash['http.max_content_length'] = node['elasticsearch']['es_max_content_length']
 end


### PR DESCRIPTION
A couple fixes here
updated es_cluster to cluster_name which fixes the search
sort the list of IPs we get back so your config doesn't change randomly
I noticed in some testing that referencing the node object directly was causing elasticsearch_config to add a second "*1" listen address that was breaking things. Moved it to listen_ip which cleared that up.